### PR TITLE
Implementing Modmail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 node_modules
 .env
 *.tgz
+src/reddit/modnote/__tests__/modnotes.spec.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -6818,9 +6818,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -12830,9 +12830,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -18380,9 +18380,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonc-parser": {
@@ -22697,9 +22697,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,7 @@ import { AnonGateway } from "./gateway/anon";
 import { OauthGateway } from "./gateway/oauth";
 import { makeDebug } from "./helper/debug";
 import { CommentControls } from "./reddit/comment/controls";
+import { ModmailControls } from "./reddit/modmail/controls";
 import { PostControls } from "./reddit/post/controls";
 import { SubredditControls } from "./reddit/subreddit/controls";
 import { MyUserControls } from "./reddit/user/my-user/controls";
@@ -45,8 +46,8 @@ export interface ClientOptions {
    *
    * > * Change your client's User-Agent string to something unique and
    * >   descriptive, including the target platform, a unique application
-   * >   identifier, a version string, and your username as contact information,
-   * >   in the following format:
+   * >   identifier, a version string, and your username as contact
+   * information, >   in the following format:
    * >   `<platform>:<app ID>:<version string> (by /u/<reddit username>)`
    * >     * Example: `User-Agent: android:com.example.myredditapp:v1.2.3 (by
    * >       /u/kemitche)`
@@ -56,8 +57,9 @@ export interface ClientOptions {
    * >     * Including the version number and updating it as you build your
    * >       application allows us to safely block old buggy/broken versions of
    * >       your app.
-   * >     * **NEVER lie about your user-agent.** This includes spoofing popular
-   * >       browsers and spoofing other bots. We will ban liars with extreme
+   * >     * **NEVER lie about your user-agent.** This includes spoofing
+   * popular >       browsers and spoofing other bots. We will ban liars with
+   * extreme
    * >       prejudice.
    *
    * [rls]: https://github.com/reddit-archive/reddit/wiki/api#rules
@@ -66,10 +68,11 @@ export interface ClientOptions {
 }
 
 /**
- * The main Client class. This is the primary way you will interact with snoots.
+ * The main Client class. This is the primary way you will interact with
+ * snoots.
  *
- * Every Client instance is fully independent, so you are free to create as many
- * as you require.
+ * Every Client instance is fully independent, so you are free to create as
+ * many as you require.
  *
  * @example The most common way to use snoots is to make a client
  * ```ts
@@ -134,13 +137,16 @@ export class Client {
   public readonly subreddits: SubredditControls;
   /** Controls for interacting with users. */
   public readonly users: UserControls;
+  /** Controls for interacting with modmail */
+  public readonly modmail: ModmailControls;
 
   /**
    * The Gateway to the Reddit API.
    *
-   * You can use this directly, but you most likely don't want to. If you end up
-   * needing this in order to interact with the Reddit API please open an issue
-   * or submit a pull request so we can add official support for your use case.
+   * You can use this directly, but you most likely don't want to. If you end
+   * up needing this in order to interact with the Reddit API please open an
+   * issue or submit a pull request so we can add official support for your use
+   * case.
    *
    * @internal
    */
@@ -189,6 +195,7 @@ export class Client {
     this.posts = new PostControls(this);
     this.subreddits = new SubredditControls(this);
     this.users = new UserControls(this);
+    this.modmail = new ModmailControls(this);
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,10 +9,12 @@ import { OauthGateway } from "./gateway/oauth";
 import { makeDebug } from "./helper/debug";
 import { CommentControls } from "./reddit/comment/controls";
 import { ModmailControls } from "./reddit/modmail/controls";
+import { ModeratorNoteControls } from "./reddit/modnote/controls";
 import { PostControls } from "./reddit/post/controls";
 import { SubredditControls } from "./reddit/subreddit/controls";
 import { MyUserControls } from "./reddit/user/my-user/controls";
 import { UserControls } from "./reddit/user/other-user/controls";
+import { WikiControls } from "./reddit/wiki/controls";
 
 const debug = makeDebug("class:Client");
 
@@ -47,7 +49,7 @@ export interface ClientOptions {
    * > * Change your client's User-Agent string to something unique and
    * >   descriptive, including the target platform, a unique application
    * >   identifier, a version string, and your username as contact
-   * information, >   in the following format:
+   * >   information, in the following format:
    * >   `<platform>:<app ID>:<version string> (by /u/<reddit username>)`
    * >     * Example: `User-Agent: android:com.example.myredditapp:v1.2.3 (by
    * >       /u/kemitche)`
@@ -58,9 +60,8 @@ export interface ClientOptions {
    * >       application allows us to safely block old buggy/broken versions of
    * >       your app.
    * >     * **NEVER lie about your user-agent.** This includes spoofing
-   * popular >       browsers and spoofing other bots. We will ban liars with
-   * extreme
-   * >       prejudice.
+   * >       popular browsers and spoofing other bots. We will ban liars with
+   * >       extreme prejudice.
    *
    * [rls]: https://github.com/reddit-archive/reddit/wiki/api#rules
    */
@@ -139,6 +140,10 @@ export class Client {
   public readonly users: UserControls;
   /** Controls for interacting with modmail */
   public readonly modmail: ModmailControls;
+  /** Controls for interacting with wiki pages */
+  public readonly wiki: WikiControls;
+  /** Controls for interacting with moderator notes. */
+  public readonly moderatorNotes: ModeratorNoteControls;
 
   /**
    * The Gateway to the Reddit API.
@@ -196,6 +201,8 @@ export class Client {
     this.subreddits = new SubredditControls(this);
     this.users = new UserControls(this);
     this.modmail = new ModmailControls(this);
+    this.wiki = new WikiControls(this);
+    this.moderatorNotes = new ModeratorNoteControls(this);
   }
 
   /**

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -79,6 +79,28 @@ export abstract class Gateway {
   }
 
   /**
+   * Issue a DELETE request to the Reddit API.
+   *
+   * You can use this method, but you most likely don't want to. If you end up
+   * needing this method in order to interact with the Reddit API please open an
+   * issue or submit a pull request so we can add official support for your use
+   * case.
+   *
+   * @internal
+   *
+   * @param path The path to DELETE.
+   * @param query The query params.
+   * @returns The result.
+   */
+  public async delete<T>(path: string, query: Query = {}): Promise<T> {
+    const options = await this.buildOptions(query);
+    debugRequest("DELETE", path, options);
+    const response: T = await got.delete(this.mapPath(path), options).json();
+    debugResponse("DELETE", path, response);
+    return this.unwrap(response);
+  }
+
+  /**
    * Issue a POST request to the Reddit API with x-www-form-urlencoded data.
    *
    * You can use this method, but you most likely don't want to. If you end up

--- a/src/reddit/index.ts
+++ b/src/reddit/index.ts
@@ -11,6 +11,31 @@ export { Listing } from "./listing/listing";
 export { LockableControls } from "./lockable/controls";
 export type { LockableData } from "./lockable/object";
 export { Lockable } from "./lockable/object";
+export { ModmailControls } from "./modmail/controls";
+export type {
+  ModmailConversation,
+  ModmailConversationData,
+} from "./modmail/conversation/object";
+export type { ModmailConversationOwner } from "./modmail/conversation/types";
+export type { ModmailConversationDetailedData } from "./modmail/conversationDetailed/object";
+export { ModmailConversationDetailed } from "./modmail/conversationDetailed/object";
+export type {
+  ModmailConversationDetailedDataApproveStatus,
+  ModmailConversationDetailedDataBanStatus,
+  ModmailConversationDetailedDataModeratorActionUser,
+  ModmailConversationDetailedDataMuteStatus,
+  ModmailConversationDetailedDataRecentConversation,
+  ModmailConversationModeratorAction,
+  modmailConversationModeratorActionType,
+  ModmailConversationUserData,
+} from "./modmail/conversationDetailed/types";
+export type { ModmailConversationMessageData } from "./modmail/conversationMessage/types";
+export type {
+  ModmailMuteDurationHours,
+  ModmailParticipant,
+  ModmailSort,
+  ModmailState,
+} from "./modmail/types";
 export { PostControls } from "./post/controls";
 export type { PostData, SuggestedSort } from "./post/object";
 export { Post } from "./post/object";

--- a/src/reddit/index.ts
+++ b/src/reddit/index.ts
@@ -11,6 +11,7 @@ export { Listing } from "./listing/listing";
 export { LockableControls } from "./lockable/controls";
 export type { LockableData } from "./lockable/object";
 export { Lockable } from "./lockable/object";
+
 export { ModmailControls } from "./modmail/controls";
 export type {
   ModmailConversation,
@@ -36,6 +37,16 @@ export type {
   ModmailSort,
   ModmailState,
 } from "./modmail/types";
+export { ModeratorNoteControls } from "./modnote/controls";
+export { ModeratorNote } from "./modnote/object";
+export type {
+  ModeratorNoteActionData,
+  ModeratorNoteData,
+  ModeratorNoteType,
+  ModeratorNoteTypeSearch,
+  ModeratorNoteUserNoteData,
+  ModeratorNoteUserNoteLabelType,
+} from "./modnote/types";
 export { PostControls } from "./post/controls";
 export type { PostData, SuggestedSort } from "./post/object";
 export { Post } from "./post/object";
@@ -72,3 +83,12 @@ export type { UserItemsSort } from "./user/types";
 export { VoteableControls } from "./voteable/controls";
 export type { Gildings, VoteableData } from "./voteable/object";
 export { Voteable } from "./voteable/object";
+export { WikiControls } from "./wiki/controls";
+export { WikiPage } from "./wiki/object";
+export type {
+  WikiPageData,
+  WikiPageRevisionData,
+  wikiPermissionLevel,
+  WikiSettings,
+  WikiSettingsAndEditors,
+} from "./wiki/types";

--- a/src/reddit/modmail/__tests__/modmail.spec.ts
+++ b/src/reddit/modmail/__tests__/modmail.spec.ts
@@ -1,0 +1,5 @@
+describe("modmail", () => {
+  test.todo("can bulk mark read");
+  test.todo("can get conversations");
+  test.todo("can create a new modmail conversation");
+});

--- a/src/reddit/modmail/controls.ts
+++ b/src/reddit/modmail/controls.ts
@@ -1,0 +1,211 @@
+import type { Client } from "../../client";
+import type { ModmailConversationData } from "./conversation/object";
+import type { ModmailConversationUserData } from "./conversationDetailed/types";
+import type { ModmailConversationMessageData } from "./conversationMessage/types";
+import type {
+  ModmailMuteDurationHours,
+  ModmailSort,
+  ModmailState,
+} from "./types";
+
+import { BaseControls } from "../base-controls";
+import { ModmailConversation } from "./conversation/object";
+import { ModmailConversationDetailed } from "./conversationDetailed/object";
+
+/**
+ * Various methods to allow you to interact with modmail
+ *
+ * @category Controls
+ */
+export class ModmailControls extends BaseControls {
+  /** @internal */
+  constructor(client: Client) {
+    super(client, "");
+  }
+
+  /**
+   *
+   * @param subreddit A subreddit or array of subreddit display names
+   * @param filterState Mark only certain conversations as read according to their state.
+   * @returns
+   * @throws `HTTPError` if
+   */
+  async bulkMarkRead(
+    subreddit: string | Array<string>,
+    filterState: ModmailState
+  ) {
+    if (subreddit instanceof Array<string>) subreddit = subreddit.join(",");
+    return this.gateway.post<unknown>("api/mod/bulk_read", {
+      entity: subreddit,
+      state: filterState,
+    });
+  }
+
+  /**
+   *
+   * @param subreddit A subreddit or array of subreddit display names
+   * @param after A modmail conversation ID
+   * @param limit the maximum number of modmail conversations as a number between `0` and `100` (defaults to `25`)
+   * @param sort The order in which to sort the returned conversations. Either `mod`, `recent`, `user`, or `unread` (defaults to `recent`)
+   * @param state Filter the returned modmail conversations by type. Defaults to `all`
+   * @returns
+   * @throws `HTTPError` if `after` parameter does not correspond to a conversation ID
+   */
+  async getConversations(
+    subreddit: string | Array<string>,
+    after?: string,
+    limit: number = 25,
+    sort: ModmailSort = "recent",
+    state: ModmailState = "all"
+  ): Promise<unknown> {
+    if (subreddit instanceof Array<string>) subreddit = subreddit.join(",");
+    if (limit < 0 || limit > 100) limit = Math.min(Math.max(limit, 0), 100);
+
+    const response = await this.gateway.get<{
+      conversations: Record<string, ModmailConversationData>;
+      messages: Record<string, ModmailConversationMessageData>;
+    }>("api/mod/conversations", {
+      after,
+      entity: subreddit,
+      limit,
+      sort,
+      state,
+    });
+
+    return Object.values(response.conversations).map(
+      x => new ModmailConversation(this, x)
+    );
+  }
+
+  /*
+    async createNewConversation( ){
+
+    }
+    */
+
+  async getConversation(conversationID: string, markRead: boolean) {
+    const results = await this.gateway.get<{
+      conversation: ModmailConversationData;
+      messages: Record<string, ModmailConversationMessageData>;
+      user: ModmailConversationUserData;
+      modActions: unknown;
+    }>(`api/mod/conversations/${conversationID}`, { markRead });
+    return new ModmailConversationDetailed(this, {
+      ...results.conversation,
+      messages: Object.values(results.messages),
+      user: results.user,
+      modActions: results.modActions,
+    } as ModmailConversationDetailed);
+  }
+
+  /*
+    async replyToConversation(
+        conversationID: string,
+        isAuthorHidden: boolean,
+        isInternal: boolean,
+        body: string // markdown
+    ){
+
+    }
+    */
+
+  async approveParticipant(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/approve`,
+      {}
+    );
+  }
+
+  async archiveConversation(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/archive`,
+      {}
+    );
+  }
+
+  async disapproveParticipant(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/disapprove`,
+      {}
+    );
+  }
+
+  async highlightConversation(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/highlight`,
+      {}
+    );
+  }
+
+  /*
+    async unhighlightConversation(conversationID: string){
+        return this.gateway.delete(`api/mod/conversations/${conversationID}/highlight`, {})
+    }
+    */
+
+  async muteParticipant(
+    conversationID: string,
+    duration: ModmailMuteDurationHours
+  ) {
+    return this.gateway.post(`api/mod/conversations/${conversationID}/mute`, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      num_hours: duration,
+    });
+  }
+
+  /**
+   *
+   * @param conversationID
+   * @param duration An integer between 1 and 999
+   * @returns
+   */
+  async tempBanParticipant(conversationID: string, duration: number) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/temp_ban`,
+      { duration }
+    );
+  }
+
+  async unarchiveConversation(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/unarchive`,
+      {}
+    );
+  }
+
+  async unbanParticipant(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/unban`,
+      {}
+    );
+  }
+
+  async unmuteParticipant(conversationID: string) {
+    return this.gateway.post(
+      `api/mod/conversations/${conversationID}/unmute`,
+      {}
+    );
+  }
+
+  /*
+    async markAsRead( conversationIDs: string | string[] ){
+
+    }
+    */
+
+  async getSubreddits() {
+    return this.gateway.get("api/mod/conversations/subreddits");
+  }
+
+  /*
+    async markAsUnread( conversationIDs: string[] ){
+
+    }
+    */
+
+  /*
+    async getUnreadCount( ){
+
+    }
+    */
+}

--- a/src/reddit/modmail/controls.ts
+++ b/src/reddit/modmail/controls.ts
@@ -1,6 +1,9 @@
 import type { Client } from "../../client";
 import type { ModmailConversationData } from "./conversation/object";
-import type { ModmailConversationUserData } from "./conversationDetailed/types";
+import type {
+  ModmailConversationModeratorAction,
+  ModmailConversationUserData,
+} from "./conversationDetailed/types";
 import type { ModmailConversationMessageData } from "./conversationMessage/types";
 import type {
   ModmailMuteDurationHours,
@@ -24,11 +27,11 @@ export class ModmailControls extends BaseControls {
   }
 
   /**
-   *
+   * Bulk mark as read modmail conversations by state
    * @param subreddit A subreddit or array of subreddit display names
    * @param filterState Mark only certain conversations as read according to their state.
    * @returns
-   * @throws `HTTPError` if
+   * @throws `HTTPError` in all circumstances
    */
   async bulkMarkRead(
     subreddit: string | Array<string>,
@@ -42,7 +45,7 @@ export class ModmailControls extends BaseControls {
   }
 
   /**
-   *
+   * Get undetailed `ModmailConversation` objects
    * @param subreddit A subreddit or array of subreddit display names
    * @param after A modmail conversation ID
    * @param limit the maximum number of modmail conversations as a number between `0` and `100` (defaults to `25`)
@@ -83,18 +86,24 @@ export class ModmailControls extends BaseControls {
     }
     */
 
+  /**
+   * Get `ModmailConversationDetailed` for a given conversation ID
+   * @param conversationID ID of the modmail conversation in question
+   * @param markRead Mark the modmail as read at the same time
+   * @returns
+   */
   async getConversation(conversationID: string, markRead: boolean) {
     const results = await this.gateway.get<{
       conversation: ModmailConversationData;
       messages: Record<string, ModmailConversationMessageData>;
       user: ModmailConversationUserData;
-      modActions: unknown;
+      modActions: Record<string, ModmailConversationModeratorAction>;
     }>(`api/mod/conversations/${conversationID}`, { markRead });
     return new ModmailConversationDetailed(this, {
       ...results.conversation,
       messages: Object.values(results.messages),
       user: results.user,
-      modActions: results.modActions,
+      modActions: Object.values(results.modActions),
     } as ModmailConversationDetailed);
   }
 
@@ -109,6 +118,11 @@ export class ModmailControls extends BaseControls {
     }
     */
 
+  /**
+   * Give approved status to the original sender of the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async approveParticipant(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/approve`,
@@ -116,6 +130,11 @@ export class ModmailControls extends BaseControls {
     );
   }
 
+  /**
+   * Archive a modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async archiveConversation(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/archive`,
@@ -123,6 +142,11 @@ export class ModmailControls extends BaseControls {
     );
   }
 
+  /**
+   * Remove approved status from original sender of the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async disapproveParticipant(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/disapprove`,
@@ -130,6 +154,11 @@ export class ModmailControls extends BaseControls {
     );
   }
 
+  /**
+   * Highlight the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async highlightConversation(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/highlight`,
@@ -143,6 +172,12 @@ export class ModmailControls extends BaseControls {
     }
     */
 
+  /**
+   * Temporarily mute the original sender of the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @param duration Duration in hours to mute participant of conversation
+   * @returns
+   */
   async muteParticipant(
     conversationID: string,
     duration: ModmailMuteDurationHours
@@ -154,9 +189,9 @@ export class ModmailControls extends BaseControls {
   }
 
   /**
-   *
-   * @param conversationID
-   * @param duration An integer between 1 and 999
+   *Temporarily ban the original sender of the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @param duration Number between 1 and 999 in days for which to ban participant
    * @returns
    */
   async tempBanParticipant(conversationID: string, duration: number) {
@@ -166,6 +201,11 @@ export class ModmailControls extends BaseControls {
     );
   }
 
+  /**
+   * Unarchive the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async unarchiveConversation(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/unarchive`,
@@ -173,6 +213,11 @@ export class ModmailControls extends BaseControls {
     );
   }
 
+  /**
+   * Unban the original sender of the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async unbanParticipant(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/unban`,
@@ -180,6 +225,11 @@ export class ModmailControls extends BaseControls {
     );
   }
 
+  /**
+   * Unmute the original sender of the modmail conversation
+   * @param conversationID ID of the modmail conversation in question
+   * @returns
+   */
   async unmuteParticipant(conversationID: string) {
     return this.gateway.post(
       `api/mod/conversations/${conversationID}/unmute`,
@@ -193,6 +243,10 @@ export class ModmailControls extends BaseControls {
     }
     */
 
+  /**
+   * Undocumented
+   * @returns
+   */
   async getSubreddits() {
     return this.gateway.get("api/mod/conversations/subreddits");
   }

--- a/src/reddit/modmail/controls.ts
+++ b/src/reddit/modmail/controls.ts
@@ -60,7 +60,7 @@ export class ModmailControls extends BaseControls {
     limit: number = 25,
     sort: ModmailSort = "recent",
     state: ModmailState = "all"
-  ): Promise<unknown> {
+  ): Promise<Array<ModmailConversation>> {
     if (subreddit instanceof Array<string>) subreddit = subreddit.join(",");
     if (limit < 0 || limit > 100) limit = Math.min(Math.max(limit, 0), 100);
 

--- a/src/reddit/modmail/conversation/object.ts
+++ b/src/reddit/modmail/conversation/object.ts
@@ -2,6 +2,7 @@ import type { ModmailControls } from "../controls";
 import type { ModmailMuteDurationHours, ModmailParticipant } from "../types";
 import type { ModmailConversationOwner } from "./types";
 
+/** The attributes specific to `ModmailConversation` objects */
 export interface ModmailConversationData {
   /** Unknown */
   isAuto: boolean;
@@ -19,11 +20,13 @@ export interface ModmailConversationData {
    */
   isRepliable: boolean;
 
+  /** Unknown */
   lastUserUpdate: string; // Formatted timestamp
 
   /** Unknown, perhaps whether it is a mod discussion */
   isInternal: boolean;
 
+  /** Unknown */
   lastModUpdate: unknown; // Probably formatted timestamp
 
   /** Array of information on users who have sent messages within the
@@ -31,15 +34,19 @@ export interface ModmailConversationData {
    */
   authors: Array<ModmailParticipant>; // array
 
+  /** Unknown */
   lastUpdated: string; // Formatted timestamp
 
+  /** Unknown */
   legacyFirstMessageId: string;
 
   /** Unknown. 0 appears to be unreplied to, 1 has some sort of reply? */
   state: number; // Not sure what this state is
 
+  /** Unknown */
   conversationType: string; // 'sr_user' ?
 
+  /** Unknown */
   lastUnread: string; // Formatted timestamp
 
   /** Unknown, perhaps describes the subreddit to which the modmail
@@ -60,28 +67,66 @@ export interface ModmailConversationData {
   numMessages: number;
 }
 
+/** A single undetailed modmail conversation */
 export class ModmailConversation implements ModmailConversationData {
+  /** @inheritDoc */
   isAuto: boolean;
+
+  /** @inheritDoc */
   participant: ModmailParticipant;
+
+  /** @inheritDoc */
   objIds: unknown;
+
+  /** @inheritDoc */
   isRepliable: boolean;
+
+  /** @inheritDoc */
   lastUserUpdate: string;
+
+  /** @inheritDoc */
   isInternal: boolean;
+
+  /** @inheritDoc */
   lastModUpdate: unknown;
+
+  /** @inheritDoc */
   authors: Array<ModmailParticipant>;
+
+  /** @inheritDoc */
   lastUpdated: string;
+
+  /** @inheritDoc */
   legacyFirstMessageId: string;
+
+  /** @inheritDoc */
   state: number;
+
+  /** @inheritDoc */
   conversationType: string;
+
+  /** @inheritDoc */
   lastUnread: string;
+
+  /** @inheritDoc */
   owner: ModmailConversationOwner;
+
+  /** @inheritDoc */
   subject: string;
+
+  /** @inheritDoc */
   id: string;
+
+  /** @inheritDoc */
   isHighlighted: boolean;
+
+  /** @inheritDoc */
   numMessages: number;
 
+  /** @internal */
   private readonly controls: ModmailControls;
 
+  /** @internal */
   constructor(controls: ModmailControls, data: ModmailConversationData) {
     this.isAuto = data.isAuto;
     this.participant = data.participant;
@@ -104,19 +149,30 @@ export class ModmailConversation implements ModmailConversationData {
     this.controls = controls;
   }
 
+  /**
+   * Fetch a detailed view of the modmail conversation
+   * @param markRead Mark the modmail conversation as read at the same time
+   */
   async getDetailed(markRead: boolean) {
     return this.controls.getConversation(this.id, markRead);
   }
 
+  /** Give approved status to the original sender of the modmail conversation */
   async approveParticipant() {
     return this.controls.approveParticipant(this.id);
   }
+
+  /** Archive the modmail conversation */
   async archive() {
     return this.controls.archiveConversation(this.id);
   }
+
+  /** Remove approved status from original sender of the modmail conversation */
   async disapproveParticipant() {
     return this.controls.disapproveParticipant(this.id);
   }
+
+  /** Highlight the modmail conversation */
   async highlight() {
     return this.controls.highlightConversation(this.id);
   }
@@ -126,22 +182,34 @@ export class ModmailConversation implements ModmailConversationData {
    * this.controls.unhighlightConversation(this.id) }
    */
 
+  /**
+   * Temporarily mute the original sender of the modmail conversation
+   * @param duration Duration for which to mute the participant (in hours)
+   */
   async muteParticipant(duration: ModmailMuteDurationHours) {
     return this.controls.muteParticipant(this.id, duration);
   }
 
+  /**
+   * Temporarily ban the original sender of the modmail conversation
+   * @param duration Duration for which to temporarily ban the
+   * participant (in days)
+   */
   async tempBanParticipant(duration: number) {
     return this.controls.tempBanParticipant(this.id, duration);
   }
 
+  /** Unarchive the modmail conversation */
   async unarchive() {
     return this.controls.unarchiveConversation(this.id);
   }
 
+  /** Unban the original sender of the modmail conversation */
   async unbanParticipant() {
     return this.controls.unbanParticipant(this.id);
   }
 
+  /** Unmute the original sender of the modmail conversation */
   async unmuteParticipant() {
     return this.controls.unmuteParticipant(this.id);
   }

--- a/src/reddit/modmail/conversation/object.ts
+++ b/src/reddit/modmail/conversation/object.ts
@@ -1,0 +1,151 @@
+import type { ModmailControls } from "../controls";
+import type { ModmailMuteDurationHours, ModmailParticipant } from "../types";
+import type { ModmailConversationOwner } from "./types";
+
+export interface ModmailConversationData {
+  /** Unknown */
+  isAuto: boolean;
+
+  /** Information on the original sender */
+  participant: ModmailParticipant;
+
+  /** Unknown, perhaps an array of objects describing the messages
+   * in the conversation */
+  objIds: unknown;
+
+  /** Whether the modmail conversation may be replied to. This probably has
+   * something to do with whether the original sender is muted or has been
+   * banned
+   */
+  isRepliable: boolean;
+
+  lastUserUpdate: string; // Formatted timestamp
+
+  /** Unknown, perhaps whether it is a mod discussion */
+  isInternal: boolean;
+
+  lastModUpdate: unknown; // Probably formatted timestamp
+
+  /** Array of information on users who have sent messages within the
+   * conversation. This list contains duplicate entries, one for each message
+   */
+  authors: Array<ModmailParticipant>; // array
+
+  lastUpdated: string; // Formatted timestamp
+
+  legacyFirstMessageId: string;
+
+  /** Unknown. 0 appears to be unreplied to, 1 has some sort of reply? */
+  state: number; // Not sure what this state is
+
+  conversationType: string; // 'sr_user' ?
+
+  lastUnread: string; // Formatted timestamp
+
+  /** Unknown, perhaps describes the subreddit to which the modmail
+   * modmail conversation belongs
+   */
+  owner: ModmailConversationOwner; // object
+
+  /** Subject of the modmail conversation */
+  subject: string;
+
+  /** ID of the conversation */
+  id: string;
+
+  /** Whether the conversation has been highlighted */
+  isHighlighted: boolean;
+
+  /** Number of messages within the modmail conversation */
+  numMessages: number;
+}
+
+export class ModmailConversation implements ModmailConversationData {
+  isAuto: boolean;
+  participant: ModmailParticipant;
+  objIds: unknown;
+  isRepliable: boolean;
+  lastUserUpdate: string;
+  isInternal: boolean;
+  lastModUpdate: unknown;
+  authors: Array<ModmailParticipant>;
+  lastUpdated: string;
+  legacyFirstMessageId: string;
+  state: number;
+  conversationType: string;
+  lastUnread: string;
+  owner: ModmailConversationOwner;
+  subject: string;
+  id: string;
+  isHighlighted: boolean;
+  numMessages: number;
+
+  private readonly controls: ModmailControls;
+
+  constructor(controls: ModmailControls, data: ModmailConversationData) {
+    this.isAuto = data.isAuto;
+    this.participant = data.participant;
+    this.objIds = data.objIds;
+    this.isRepliable = data.isRepliable;
+    this.lastUserUpdate = data.lastUserUpdate;
+    this.isInternal = data.isInternal;
+    this.authors = data.authors;
+    this.lastUpdated = data.lastUpdated;
+    this.legacyFirstMessageId = data.legacyFirstMessageId;
+    this.state = data.state;
+    this.conversationType = data.conversationType;
+    this.lastUnread = data.lastUnread;
+    this.owner = data.owner;
+    this.subject = data.subject;
+    this.id = data.id;
+    this.isHighlighted = data.isHighlighted;
+    this.numMessages = data.numMessages;
+
+    this.controls = controls;
+  }
+
+  async getDetailed(markRead: boolean) {
+    return this.controls.getConversation(this.id, markRead);
+  }
+
+  async approveParticipant() {
+    return this.controls.approveParticipant(this.id);
+  }
+  async archive() {
+    return this.controls.archiveConversation(this.id);
+  }
+  async disapproveParticipant() {
+    return this.controls.disapproveParticipant(this.id);
+  }
+  async highlight() {
+    return this.controls.highlightConversation(this.id);
+  }
+
+  /*
+   * async unhighlight(){ return
+   * this.controls.unhighlightConversation(this.id) }
+   */
+
+  async muteParticipant(duration: ModmailMuteDurationHours) {
+    return this.controls.muteParticipant(this.id, duration);
+  }
+
+  async tempBanParticipant(duration: number) {
+    return this.controls.tempBanParticipant(this.id, duration);
+  }
+
+  async unarchive() {
+    return this.controls.unarchiveConversation(this.id);
+  }
+
+  async unbanParticipant() {
+    return this.controls.unbanParticipant(this.id);
+  }
+
+  async unmuteParticipant() {
+    return this.controls.unmuteParticipant(this.id);
+  }
+
+  /* async markAsRead(){ return this.controls.markAsRead(this.id) } */
+  /* async markAsUnread(){ return this.controls.markAsUnread(this.id) } */
+}

--- a/src/reddit/modmail/conversation/types.ts
+++ b/src/reddit/modmail/conversation/types.ts
@@ -1,0 +1,5 @@
+export interface ModmailConversationOwner {
+  displayName: string;
+  type: "subreddit";
+  id: string;
+}

--- a/src/reddit/modmail/conversation/types.ts
+++ b/src/reddit/modmail/conversation/types.ts
@@ -1,5 +1,13 @@
+/** Description of the subreddit to which a modmail conversation
+ * belongs
+ */
 export interface ModmailConversationOwner {
+  /** Name of the subreddit */
   displayName: string;
+
+  /** Unknown */
   type: "subreddit";
+
+  /** prefixed thing ID */
   id: string;
 }

--- a/src/reddit/modmail/conversationDetailed/object.ts
+++ b/src/reddit/modmail/conversationDetailed/object.ts
@@ -8,20 +8,32 @@ import type {
 
 import { ModmailConversation } from "../conversation/object";
 
+/** The attributes specific to ModmailConversationDetailed objects */
 export interface ModmailConversationDetailedData
   extends ModmailConversationData {
+  /** Array of messages belonging to the conversation */
   messages: Array<ModmailConversationMessageData>;
+
+  /** Details regarding the original sender of the modmail conversation */
   user: ModmailConversationUserData;
-  modActions: ModmailConversationModeratorAction;
+
+  /** Details regarding moderator actions performed in the conversation */
+  modActions: Array<ModmailConversationModeratorAction>;
 }
 
+/** a single detailed modmail conversation */
 export class ModmailConversationDetailed
   extends ModmailConversation
   implements ModmailConversationDetailedData
 {
+  /** @inheritDoc */
   messages: Array<ModmailConversationMessageData>;
+
+  /** @inheritDoc */
   user: ModmailConversationUserData;
-  modActions: ModmailConversationModeratorAction;
+
+  /** @inheritDoc */
+  modActions: Array<ModmailConversationModeratorAction>;
 
   /** @internal */
   constructor(
@@ -30,8 +42,8 @@ export class ModmailConversationDetailed
   ) {
     super(controls, data);
 
-    (this.messages = data.messages),
-      (this.user = data.user),
-      (this.modActions = data.modActions);
+    this.messages = data.messages;
+    this.user = data.user;
+    this.modActions = data.modActions;
   }
 }

--- a/src/reddit/modmail/conversationDetailed/object.ts
+++ b/src/reddit/modmail/conversationDetailed/object.ts
@@ -1,0 +1,37 @@
+import type { ModmailControls } from "../controls";
+import type { ModmailConversationData } from "../conversation/object";
+import type { ModmailConversationMessageData } from "../conversationMessage/types";
+import type {
+  ModmailConversationModeratorAction,
+  ModmailConversationUserData,
+} from "./types";
+
+import { ModmailConversation } from "../conversation/object";
+
+export interface ModmailConversationDetailedData
+  extends ModmailConversationData {
+  messages: Array<ModmailConversationMessageData>;
+  user: ModmailConversationUserData;
+  modActions: ModmailConversationModeratorAction;
+}
+
+export class ModmailConversationDetailed
+  extends ModmailConversation
+  implements ModmailConversationDetailedData
+{
+  messages: Array<ModmailConversationMessageData>;
+  user: ModmailConversationUserData;
+  modActions: ModmailConversationModeratorAction;
+
+  /** @internal */
+  constructor(
+    controls: ModmailControls,
+    data: ModmailConversationDetailedData
+  ) {
+    super(controls, data);
+
+    (this.messages = data.messages),
+      (this.user = data.user),
+      (this.modActions = data.modActions);
+  }
+}

--- a/src/reddit/modmail/conversationDetailed/types.ts
+++ b/src/reddit/modmail/conversationDetailed/types.ts
@@ -1,52 +1,134 @@
+/** Expanded details of modmail conversation OP */
 export interface ModmailConversationUserData {
+  /** Unknown */
   recentComments: unknown;
-  muteStatus: {
-    mutCount: number;
-    isMuted: boolean;
-    endDate: unknown;
-    reason: string;
-  };
+
+  /** Details on the mute status of the user */
+  muteStatus: ModmailConversationDetailedDataMuteStatus;
+
+  /** When was the user account created */
   created: string;
-  banStatus: {
-    endDate: unknown;
-    reason: string;
-    isBanned: boolean;
-    isPermanent: boolean;
-  };
+
+  /** Details on the ban status of the user */
+  banStatus: ModmailConversationDetailedDataBanStatus;
+
+  /** Is the account suspended by Reddit */
   isSuspended: boolean;
-  approveStatus: {
-    isApproved: false;
-  };
+
+  /** Details on the approved status of the user */
+  approveStatus: ModmailConversationDetailedDataApproveStatus;
+
+  /** Is the user presently shadow banned by Reddit */
   isShadowBanned: boolean;
+
+  /** Recent posts, unknown */
   recentPosts: unknown;
+
+  /** Recent modmail conversations */
   recentConvos: Record<
     string,
-    {
-      date: string;
-      permalink: string;
-      id: string;
-      subject: string;
-    }
+    ModmailConversationDetailedDataRecentConversation
   >;
+
+  /** ID of the user */
   id: string;
 }
 
+/** Programmer friendly annotations for modmail action types */
 export enum modmailConversationModeratorActionType {
+  /** Action was to mute the user */
   muteUser = 5,
+
+  /** Action was to unmute the user */
   unmuteUser = 6,
+
+  /** Action was to give approved status to user */
   approveUser = 9,
 }
 
+/** Details on a single moderator action */
 export interface ModmailConversationModeratorAction {
+  /** Date the action was taken */
   date: string;
+
+  /** Type of action taken */
   actionTypeId: modmailConversationModeratorActionType;
+
+  /** ID of the action itself */
   id: string;
-  author: {
-    name: string;
-    isMod: boolean;
-    isAdmin: boolean;
-    isHidden: boolean;
-    id: number;
-    isDeleted: boolean;
-  };
+
+  /** Details on the person having performed the action */
+  author: ModmailConversationDetailedDataModeratorActionUser;
+}
+
+/** Details on the ban status of the user */
+export interface ModmailConversationDetailedDataBanStatus {
+  /** If banned, when does their ban end */
+  endDate: unknown;
+
+  /** If banned, what was the reason for their ban */
+  reason: string;
+
+  /** Are they presently banned */
+  isBanned: boolean;
+
+  /** Are they presently permanently banned */
+  isPermanent: boolean;
+}
+
+/** Details on the mute status of the user */
+export interface ModmailConversationDetailedDataMuteStatus {
+  /** How many times has the user been previously muted */
+  muteCount: number;
+
+  /** Are they presently muted */
+  isMuted: boolean;
+
+  /** If muted, when does their mute end */
+  endDate: unknown;
+
+  /** If muted, what was the reason for their mute */
+  reason: string;
+}
+
+/** Details on the approved status of the user */
+export interface ModmailConversationDetailedDataApproveStatus {
+  /** Is the user approved */
+  isApproved: boolean;
+}
+
+/** Details regarding a recent conversation */
+export interface ModmailConversationDetailedDataRecentConversation {
+  /** Date of the modmail conversation */
+  date: string;
+
+  /** Permanent link to the modmail conversation */
+  permalink: string;
+
+  /** ID of the modmail conversation */
+  id: string;
+
+  /** Subject of the modmail conversation */
+  subject: string;
+}
+
+/** Details pertaining to the user who performed a moderator action */
+export interface ModmailConversationDetailedDataModeratorActionUser {
+  /** Name of the user */
+  name: string;
+
+  /** Acting in a moderator capacity */
+  isMod: boolean;
+
+  /** Acting in an admin capacity */
+  isAdmin: boolean;
+
+  /** Was the username hidden when performing the action */
+  isHidden: boolean;
+
+  /** ID of the user in Base 10 */
+  id: number;
+
+  /** Is the user presently deleted */
+  isDeleted: boolean;
 }

--- a/src/reddit/modmail/conversationDetailed/types.ts
+++ b/src/reddit/modmail/conversationDetailed/types.ts
@@ -1,0 +1,52 @@
+export interface ModmailConversationUserData {
+  recentComments: unknown;
+  muteStatus: {
+    mutCount: number;
+    isMuted: boolean;
+    endDate: unknown;
+    reason: string;
+  };
+  created: string;
+  banStatus: {
+    endDate: unknown;
+    reason: string;
+    isBanned: boolean;
+    isPermanent: boolean;
+  };
+  isSuspended: boolean;
+  approveStatus: {
+    isApproved: false;
+  };
+  isShadowBanned: boolean;
+  recentPosts: unknown;
+  recentConvos: Record<
+    string,
+    {
+      date: string;
+      permalink: string;
+      id: string;
+      subject: string;
+    }
+  >;
+  id: string;
+}
+
+export enum modmailConversationModeratorActionType {
+  muteUser = 5,
+  unmuteUser = 6,
+  approveUser = 9,
+}
+
+export interface ModmailConversationModeratorAction {
+  date: string;
+  actionTypeId: modmailConversationModeratorActionType;
+  id: string;
+  author: {
+    name: string;
+    isMod: boolean;
+    isAdmin: boolean;
+    isHidden: boolean;
+    id: number;
+    isDeleted: boolean;
+  };
+}

--- a/src/reddit/modmail/conversationMessage/types.ts
+++ b/src/reddit/modmail/conversationMessage/types.ts
@@ -1,11 +1,25 @@
 import type { ModmailParticipant } from "../types";
 
+/** Data relevant to a message in a modmail conversation */
 export interface ModmailConversationMessageData {
+  /** Body of the message in HTML format */
   body: string;
+
+  /** Information pertaining to the author of the message */
   author: ModmailParticipant;
+
+  /** Is the message a private note? */
   isInternal: boolean;
+
+  /** Date the message was sent */
   date: string;
+
+  /** Body of the message in Markdown format */
   bodyMarkdown: string;
+
+  /** ID of the message */
   id: string;
+
+  /** Is the message sent by a user or a moderator (?) */
   participatingAs: "participant_user" | "moderator";
 }

--- a/src/reddit/modmail/conversationMessage/types.ts
+++ b/src/reddit/modmail/conversationMessage/types.ts
@@ -1,0 +1,11 @@
+import type { ModmailParticipant } from "../types";
+
+export interface ModmailConversationMessageData {
+  body: string;
+  author: ModmailParticipant;
+  isInternal: boolean;
+  date: string;
+  bodyMarkdown: string;
+  id: string;
+  participatingAs: "participant_user" | "moderator";
+}

--- a/src/reddit/modmail/types.ts
+++ b/src/reddit/modmail/types.ts
@@ -1,0 +1,49 @@
+export type ModmailState =
+  | "all"
+  | "appeals"
+  | "notifications"
+  | "inbox"
+  | "filtered"
+  | "inprogress"
+  | "mod"
+  | "archived"
+  | "default"
+  | "highlighted"
+  | "join_requests"
+  | "new";
+
+export type ModmailSort = "recent" | "mod" | "user" | "unread";
+
+/** Durations for which a user may be muted, in hours */
+export type ModmailMuteDurationHours = 72 | 168 | 672;
+
+/** Participant data for an associated message */
+export interface ModmailParticipant {
+  /** Whether the user is a moderator in the modmail conversation */
+  isMod: boolean;
+
+  /** Whether the user is an admin in the modmail conversation */
+  isAdmin: boolean;
+
+  /** Display name of the user */
+  name: string;
+
+  /** Whether the user is the original sender */
+  isOp: boolean;
+
+  /** Whether the user is the original sender (duplicate of isOp?) */
+  isParticipant: boolean;
+
+  /** Whether the user is an approved user in the subreddit to which
+   * this modmail conversation belongs */
+  isApproved: boolean;
+
+  /** Whether the username was hidden for this reply */
+  isHidden: boolean;
+
+  /** User ID. Probably in base 10 */
+  id: number;
+
+  /** Unknown */
+  isDeleted: boolean;
+}

--- a/src/reddit/modmail/types.ts
+++ b/src/reddit/modmail/types.ts
@@ -1,3 +1,4 @@
+/** Possible modmail conversation states against which to filter */
 export type ModmailState =
   | "all"
   | "appeals"
@@ -12,6 +13,7 @@ export type ModmailState =
   | "join_requests"
   | "new";
 
+/** Possible modmail conversation sortings */
 export type ModmailSort = "recent" | "mod" | "user" | "unread";
 
 /** Durations for which a user may be muted, in hours */

--- a/src/reddit/modnote/controls.ts
+++ b/src/reddit/modnote/controls.ts
@@ -1,0 +1,201 @@
+import type { Client } from "../..";
+import type { Data } from "../../helper/types";
+import type {
+  ModeratorNoteData,
+  ModeratorNoteTypeSearch,
+  ModeratorNoteUserNoteLabelType,
+} from "./types";
+
+import { BaseControls } from "../..";
+import { ModeratorNote } from "./object";
+
+const moderatorNoteAPIEndpoint = "api/mod/notes";
+
+/**
+ * Various methods to allow you to interact with moderator notes.
+ *
+ * @category Controls
+ */
+export class ModeratorNoteControls extends BaseControls {
+  /** @internal */
+  constructor(client: Client) {
+    super(client, "ModNote_");
+  }
+
+  /** @internal */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  private noteFromRedditData(data: any): ModeratorNote {
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    return new ModeratorNote(this, {
+      moderatorActionData: {
+        action: data.mod_action_data.action,
+        redditId: data.mod_action_data.reddit_id,
+        details: data.mod_action_data.details,
+        description: data.mod_action_data.description,
+      },
+      subreddit: data.subreddit,
+      user: data.user,
+      operator: data.operator,
+      id: data.id,
+      userNoteData: {
+        note: data.user_note_data.note,
+        redditId: data.user_note_data.reddit_id,
+        label: data.user_note_data.label,
+      },
+      createdAt: data.created_at,
+      cursor: data.cursor,
+      type: data.type,
+    });
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+  }
+
+  /**
+   * Deletes a moderator note
+   *
+   * @param noteId a unique ID for the note to be deleted (should have a ModNote_ prefix)
+   * @param subreddit subreddit name (not prefixed)
+   * @param user account username (not prefixed)
+   */
+  async deleteNote(noteId: string, subreddit: string, user: string) {
+    return this.gateway.delete(moderatorNoteAPIEndpoint, {
+      subreddit,
+      user,
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      note_id: noteId,
+    });
+  }
+
+  /**
+   * Retrieve usernotes for a user on a given subreddit filtered by type
+   *
+   * @param subreddit subreddit name (not prefixed)
+   * @param user account username (not prefixed)
+   * @param filter To be used for querying specific types of mod notes
+   * @param limit The number of mod notes to return in the response payload (default 25, max 100)
+   * @param before An encoded string used for pagination with mod notes
+   */
+  async getNotes(
+    subreddit: string,
+    user: string,
+    filter: ModeratorNoteTypeSearch = "ALL",
+    limit: number = 25,
+    before?: string
+  ): Promise<Array<ModeratorNote>> {
+    if (limit > 100) limit = 100;
+
+    const redditResponse = await this.gateway.get<{
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      mod_notes: Array<ModeratorNoteData>;
+    }>(moderatorNoteAPIEndpoint, {
+      subreddit,
+      user,
+      filter,
+      limit,
+      before,
+    });
+
+    return redditResponse.mod_notes.map(data => this.noteFromRedditData(data));
+  }
+
+  /**
+   * Create a moderator note for a user on a subreddit, optionally linking to
+   * content. Returns newly created note
+   *
+   * @param subreddit Subreddit display name
+   * @param user username targetted
+   * @param note String of up to 250 characters to be made as a note
+   * @param label Optional label to add to the note
+   * @param redditId prefixed ID of comment or submission to link note to
+   */
+  async createNote(
+    subreddit: string,
+    user: string,
+    note: string,
+    label?: ModeratorNoteUserNoteLabelType,
+    redditId?: string
+  ): Promise<ModeratorNote> {
+    const payload = { subreddit, user, note } as Data;
+    if (label) payload.label = label;
+
+    if (redditId) payload.reddit_id = redditId;
+    const result = await this.gateway.post<{ created: Data }>(
+      moderatorNoteAPIEndpoint,
+      payload
+    );
+    return this.noteFromRedditData(result.created);
+  }
+
+  /**
+   * Fetch the most recent moderator note made for each of a subreddit-username
+   * pair. These are returned as a flat array, with the index of each entry
+   * matching the index of the corresponding subreddit-username pair supplied
+   * to the function
+   *
+   * @param subredditUsernamePairs Array of tuples. The first element of the
+   * tuple is a subreddit display name, the second element is a corresponding
+   * username. For each tuple in the array, the most recent moderator note for
+   * that subreddit-username pair will be returned. Duplicate entries result
+   * in undefined behaviour. The array of tuples must have a maximum of 500
+   * entries.
+   */
+  async getRecent(
+    subredditUsernamePairs: Array<[string, string]>
+  ): Promise<Array<ModeratorNote>> {
+    // Reduce down pairs for reddit API format (CSV)
+    // eslint-disable-next-line unicorn/no-array-reduce
+    const [subreddits, users] = subredditUsernamePairs.reduce(
+      (previous, current) => {
+        return [previous[0] + "," + current[0], previous[1] + "," + current[1]];
+      }
+    );
+
+    // Await response from API in order to post-process response
+    const results = await this.gateway.get<{
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      mod_notes: Array<ModeratorNoteData>;
+    }>("api/mod/notes/recent", { subreddits, users });
+
+    // Transform response into ModeratorNote instances
+    return results.mod_notes.map(data => this.noteFromRedditData(data));
+  }
+
+  /**
+   * Utility function for fetching the subreddit to which the moderator note pertains
+   * @internal
+   * @param data The moderator note regarding which the subreddit is of interest
+   */
+  getSubreddit(data: ModeratorNoteData) {
+    return this.client.subreddits.fetch(data.subreddit);
+  }
+
+  /**
+   * Utility function for fetching the user that resulted in the creation of the moderator note
+   * @internal
+   * @param data The moderator note regarding which the subreddit is of interest
+   */
+  getOperator(data: ModeratorNoteData) {
+    return this.client.users.fetch(data.operator);
+  }
+
+  /** Utility function for fetching the user to which the moderator note pertains
+   * @internal
+   * @param data The moderator note regarding which the subreddit is of interest
+   */
+  getUser(data: ModeratorNoteData) {
+    return this.client.users.fetch(data.user);
+  }
+
+  /** Utility function for fetching the content to which the note pertains.
+   * Returns undefined if the note does not link to content
+   * @internal
+   * @param data The moderator note regarding which the subreddit is of interest
+   */
+  getContent(data: ModeratorNoteData) {
+    if (!data.userNoteData.redditId) return;
+    return data.userNoteData.redditId.startsWith("t1_")
+      ? this.client.comments.fetch(data.userNoteData.redditId)
+      : this.client.posts.fetch(data.userNoteData.redditId);
+  }
+}

--- a/src/reddit/modnote/object.ts
+++ b/src/reddit/modnote/object.ts
@@ -1,0 +1,66 @@
+import type { ModeratorNoteControls } from "./controls";
+import type {
+  ModeratorNoteActionData,
+  ModeratorNoteData,
+  ModeratorNoteType,
+  ModeratorNoteUserNoteData,
+} from "./types";
+
+/** A single moderator note */
+export class ModeratorNote implements ModeratorNoteData {
+  moderatorActionData: ModeratorNoteActionData;
+  subreddit: string;
+  user: string;
+  operator: string;
+  id: string;
+  userNoteData: ModeratorNoteUserNoteData;
+  createdAt: number;
+  cursor?: string;
+  type: ModeratorNoteType;
+
+  protected controls: ModeratorNoteControls;
+
+  /** @internal */
+  constructor(controls: ModeratorNoteControls, data: ModeratorNoteData) {
+    this.controls = controls;
+
+    this.moderatorActionData = data.moderatorActionData;
+    this.subreddit = data.subreddit;
+    this.user = data.user;
+    this.operator = data.operator;
+    this.id = data.id;
+    this.userNoteData = data.userNoteData;
+    this.createdAt = data.createdAt;
+    this.cursor = data.cursor;
+    this.type = data.type;
+  }
+
+  /** Utility function for fetching the subreddit to which the moderator note
+   * pertains */
+  getSubreddit() {
+    return this.controls.getSubreddit(this);
+  }
+
+  /** Utility function for fetching the user that resulted in the creation of
+   * the moderator note */
+  getOperator() {
+    return this.controls.getOperator(this);
+  }
+
+  /** Utility function for fetching the user to which the moderator note
+   * pertains */
+  getUser() {
+    return this.controls.getUser(this);
+  }
+
+  /** Utility function for fetching the content to which the note pertains.
+   *  Returns undefined if the note does not link to content */
+  getContent() {
+    return this.controls.getContent(this);
+  }
+
+  /** Deletes the moderator note in question */
+  delete() {
+    return this.controls.deleteNote(this.id, this.subreddit, this.user);
+  }
+}

--- a/src/reddit/modnote/types.ts
+++ b/src/reddit/modnote/types.ts
@@ -1,0 +1,88 @@
+/** Values that the type property that a moderator note might take */
+export type ModeratorNoteType =
+  | "NOTE"
+  | "APPROVAL"
+  | "REMOVAL"
+  | "BAN"
+  | "MUTE"
+  | "INVITE"
+  | "SPAM"
+  | "CONTENT_CHANGE"
+  | "MOD_ACTION";
+
+/** Search types that the API will accept */
+export type ModeratorNoteTypeSearch = ModeratorNoteType | "ALL";
+
+/** Values that the label property that a moderator note might take */
+export type ModeratorNoteUserNoteLabelType =
+  | "SOLID_CONTRIBUTOR"
+  | "HELPFUL_USER"
+  | "SPAM_WATCH"
+  | "SPAM_WARNING"
+  | "ABUSE_WARNING"
+  | "BOT_BAN"
+  | "PERMA_BAN"
+  | "BAN"
+  | null;
+
+/** Moderator note netails specific to moderator action that created the note */
+export interface ModeratorNoteActionData {
+  // TO DO: define type for possible values of this property
+  /** Enum describing the action that resulted in the note creation, if
+   * through moderator action */
+  action: string | null;
+
+  /** Prefixed content ID to which the note pertains or null */
+  redditId: string | null;
+
+  /** UNKNOWN */
+  details: string | null;
+
+  /** UNKNOWN */
+  description: unknown | null;
+}
+
+/** Moderator note details specific to the note itself */
+export interface ModeratorNoteUserNoteData {
+  /** A string of maximum length 250 that might be associated with the moderator
+   * note */
+  note: string | null;
+
+  /** A prefixed ID of content to which the note pertains or null */
+  redditId: string | null;
+
+  /** The label associated with this note or null */
+  label: ModeratorNoteUserNoteLabelType;
+}
+
+/** The attributes specific to ModeratorNote objects */
+export interface ModeratorNoteData {
+  /** Details where note resulted from moderator action */
+  moderatorActionData: ModeratorNoteActionData;
+
+  /** Display name of the subreddit to which the note pertains */
+  subreddit: string;
+
+  /** Display name of the user to which the note pertains */
+  user: string;
+
+  /** Display name of the user that created, directly or indirectly */
+  operator: string;
+
+  /** Prefixed ID of the moderator note */
+  id: string;
+
+  /** Details where the note links to content, has a label, or has text */
+  userNoteData: ModeratorNoteUserNoteData;
+
+  /** Time of creation (TODO: Figure out if seconds or milliseconds) */
+  createdAt: number;
+
+  /** Where the note is one of a list, this field represents its place in
+   * said list */
+  cursor?: string;
+
+  /** A description of how the note came to exist, either by manual
+   * addition or as a result of a moderator action */
+  type: ModeratorNoteType;
+}

--- a/src/reddit/subreddit/controls.ts
+++ b/src/reddit/subreddit/controls.ts
@@ -56,7 +56,8 @@ export interface BanOptions {
 /** Extra options for submitting a post. */
 export interface TextPostOptions {
   /**
-   * Whether or not to send inbox replies for the new post (defaults to `true`).
+   * Whether or not to send inbox replies for the new post (defaults to
+   * `true`).
    *
    * If you want to change this later you can use
    * {@link Post.enableInboxReplies} and {@link Post.disableInboxReplies}.
@@ -79,8 +80,8 @@ export interface TextPostOptions {
 /** Extra options for submitting a link post. */
 export interface LinkPostOptions extends TextPostOptions {
   /**
-   * Whether or not to error if this link has been submitted before (defaults to
-   * `false`).
+   * Whether or not to error if this link has been submitted before (defaults
+   * to `false`).
    */
   unique?: boolean;
 }

--- a/src/reddit/wiki/__tests__/wiki.spec.ts
+++ b/src/reddit/wiki/__tests__/wiki.spec.ts
@@ -1,0 +1,12 @@
+describe("Wiki", () => {
+  test.todo("can get the content of a wiki page");
+  test.todo("can add an editor to a wiki page");
+  test.todo("can remove an editor from a wiki page");
+  test.todo("can edit the settings on a wiki page");
+  test.todo("can edit a wiki page");
+  test.todo("can get the revision history for a wiki page");
+  test.todo("can get the wiki revision history for a subreddit");
+  test.todo("can revert to a given revision");
+  test.todo("can get the discussions for a wiki page");
+  test.todo("can get a list of wiki pages on a subreddit");
+});

--- a/src/reddit/wiki/controls.ts
+++ b/src/reddit/wiki/controls.ts
@@ -1,0 +1,291 @@
+import type { Client } from "../../client";
+import type { Listing } from "../listing/listing";
+import type { RedditObject } from "../types";
+import type {
+  WikiPageRevisionData,
+  wikiPermissionLevel,
+  WikiSettings,
+  WikiSettingsAndEditors,
+} from "./types";
+
+import { BaseControls } from "../base-controls";
+import { fakeListingAfter } from "../listing/util";
+import { WikiRevisionsListing } from "./listing";
+import { WikiPage } from "./object";
+
+/**
+ * The base controls for interacting with wiki pages
+ *
+ * @category Controls
+ */
+export class WikiControls extends BaseControls {
+  /** @internal */
+  constructor(client: Client) {
+    super(client, "");
+  }
+
+  /**
+   * @internal
+   * Allow/deny a username to edit a wiki page
+   *
+   * @param act The action to take, `del` removes an editor, `add` adds an editor
+   * @param page The name of an existing wiki page
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param username the name of an existing user
+   */
+  private async allowEditor(
+    act: "del" | "add",
+    page: string,
+    subreddit: string,
+    username: string
+  ) {
+    return this.gateway.post<void>(
+      `r/${subreddit}/api/wiki/alloweditor/${act}`,
+      { page, username }
+    );
+  }
+
+  /**
+   * Add a user as an editor on a wiki page
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing wiki page
+   * @param username the name of an existing user
+   * @returns Does not return anything
+   */
+  async addEditor(subreddit: string, page: string, username: string) {
+    return this.allowEditor("add", page, subreddit, username);
+  }
+
+  /**
+   * Remove a user as an editor on a wiki page
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing wiki page
+   * @param username the name of an existing user
+   * @returns Does not return anything
+   */
+  async removeEditor(subreddit: string, page: string, username: string) {
+    return this.allowEditor("del", page, subreddit, username);
+  }
+
+  /**
+   * Edit or create a wiki page
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing page or new wiki page to create
+   * @param content String containing desired content of the wiki page (to edit or create) in markdown format
+   * @param previous The starting point revision for this edit
+   * @param reason A string up to 256 characters long, consisting of printable characters
+   * @returns Returns an empty object
+   */
+  async editPage(
+    subreddit: string,
+    page: string,
+    content: string,
+    reason?: string,
+    previous?: string
+  ) {
+    const queryObject: Record<string, string> = { content, page };
+    if (reason != undefined) queryObject.reason = reason;
+    if (previous != undefined) queryObject.previous = previous;
+    return this.gateway.post<Record<string, never>>(
+      `r/${subreddit}/api/wiki/edit`,
+      queryObject
+    );
+  }
+
+  /**
+   * Toggle the public visibility of a wiki page revision
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing wiki page
+   * @param revision a wiki revision ID
+   * @returns Returns boolean indicating whether the page is now hidden (`true` indicates it is hidden)
+   */
+  async toggleVisibility(subreddit: string, page: string, revision: string) {
+    const response = await this.gateway.post<{ status: boolean }>(
+      `r/${subreddit}/api/wiki/hide`,
+      { page, revision }
+    );
+    return response.status;
+  }
+
+  /**
+   * Revert a wiki page to revision
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing wiki page
+   * @param revision a wiki revision ID
+   * @returns UNDOCUMENTED
+   */
+  async revertPage(subreddit: string, page: string, revision: string) {
+    return this.gateway.post(`r/${subreddit}/api/wiki/revert`, {
+      page,
+      revision,
+    });
+  }
+
+  /**
+   * Get a listing of discussions for a given wiki page
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing wiki page
+   */
+  getDiscussions(/* subreddit: string, page: string */): never {
+    // return this.gateway.get(`r/${subreddit}/wiki/discussions/${page}`);
+    throw new Error("Not Implemented");
+  }
+
+  /**
+   * Retrieve a list of wiki pages in this subreddit
+   *
+   * @param subreddit The subreddit from which to fetch a list of wiki pages
+   * @returns List of wiki pages on subreddit as array of strings
+   */
+  async getPages(subreddit: string) {
+    const { data } = await this.gateway.get<{
+      kind: "wikipagelisting";
+      data: Array<string>;
+    }>(`r/${subreddit}/wiki/pages`);
+    return data;
+  }
+
+  /**
+   * Fetch a listing of recent changes made on the wiki for a subreddit
+   *
+   * @param subreddit The subreddit for whose wiki the list of revisions is
+   * sought
+   * @returns Listing of recent changes.
+   * @note Accepts more parameters, including after, before, count, limit,
+   * show, and sr_detail
+   */
+  getRecentChanges(subreddit: string): Listing<WikiPageRevisionData> {
+    const request = { url: `r/${subreddit}/wiki/revisions/`, query: {} };
+    const context = { request, client: this.client };
+    return new WikiRevisionsListing(fakeListingAfter(""), context);
+  }
+
+  /**
+   * Fetch a listing of recent changes made on a specified wiki page
+   *
+   * @param subreddit The subreddit on which exists the wiki page
+   * @param page The page for which a listing of recent changes is sought
+   * @returns A listing of recent changes for a given wiki page
+   * @note Accepts more parameters, including after, before, count, limit,
+   * show, and sr_detail
+   */
+  getRecentChangesForPage(
+    subreddit: string,
+    page: string
+  ): Listing<WikiPageRevisionData> {
+    const request = { url: `r/${subreddit}/wiki/revisions/${page}`, query: {} };
+    const context = { request, client: this.client };
+    return new WikiRevisionsListing(fakeListingAfter(""), context);
+  }
+
+  /**
+   * Transforms response from GET or POST request to
+   * `r/${subreddit}/wiki/settings/${page}` into a format that snoots uses
+   * @internal
+   * @ignore
+   * @param response Response from `r/${subreddit}/wiki/settings/${page}`
+   * @returns WikiSettingsAndEditors object
+   */
+  private buildSettingsObjectFromResponse(
+    response: WikiPageSettingsResponse
+  ): WikiSettingsAndEditors {
+    return {
+      permlevel: response.data.permlevel,
+      listed: response.data.listed,
+      editors: response.data.editors.map(object => object.data.name),
+    };
+  }
+
+  /**
+   * Retrieve the current permission settings for page
+   *
+   * @param page The name of an existing page or new wiki page to create
+   * @param subreddit The subreddit on which the wiki page exists
+   * @returns An object containing the present settings of the wiki page
+   */
+  async getSettings(
+    subreddit: string,
+    page: string
+  ): Promise<WikiSettingsAndEditors> {
+    return this.buildSettingsObjectFromResponse(
+      await this.gateway.get(`r/${subreddit}/wiki/settings/${page}`)
+    );
+  }
+
+  /**
+   * Update the permissions and visibility of wiki page
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing page
+   * @param settings An object containing the updated settings. All member fields must be set
+   * @returns An object containing the present settings of the wiki page
+   */
+  async changeSettings(
+    subreddit: string,
+    page: string,
+    settings: WikiSettings
+  ) {
+    return this.buildSettingsObjectFromResponse(
+      await this.gateway.post(`r/${subreddit}/wiki/settings/${page}`, settings)
+    );
+  }
+
+  /**
+   * Fetches the most recent, or revision `v` of a wiki page. Supposedly will
+   * compare two version if provided with `v2`, but could not reproduce.
+   *
+   * @param subreddit The subreddit on which the wiki page exists
+   * @param page The name of an existing page
+   * @param v Optional, the specific version of the wiki page to be retrieved
+   * @param v2 Optional provided `v`, compares the two versions (UNRELIABLE)
+   * @returns Wiki page object
+   */
+  async getPage(subreddit: string, page: string, v?: string, v2?: string) {
+    const oAPIArguments: Record<string, string> = {};
+    if (v != undefined) oAPIArguments.v = v;
+    if (v2 != undefined) oAPIArguments.v2 = v2;
+
+    const results = await this.gateway.get<RedditObject<object>>(
+      `r/${subreddit}/wiki/${page}`,
+      oAPIArguments
+    );
+
+    return this.wikiPageInstanceFromRedditAPI(subreddit, page, results.data);
+  }
+
+  /** @internal */
+  private wikiPageInstanceFromRedditAPI(
+    subreddit: string,
+    page: string,
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    data: any
+  ) {
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    return new WikiPage(this, {
+      subreddit,
+      page,
+      contentMD: data.content_md,
+      mayRevise: data.may_revise,
+      reason: data.reason,
+      revisionDate: data.revision_date,
+      revisionBy: data.revision_by.data.name,
+      revisionID: data.revision_id,
+      contentHTML: data.content_html,
+    });
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+  }
+}
+
+/** @internal */
+type WikiPageSettingsResponse = RedditObject<{
+  permlevel: wikiPermissionLevel;
+  editors: Array<RedditObject<{ name: string }>>;
+  listed: boolean;
+}>;

--- a/src/reddit/wiki/listing.ts
+++ b/src/reddit/wiki/listing.ts
@@ -1,0 +1,53 @@
+import type {
+  Fetcher,
+  ListingContext,
+  RedditListing,
+} from "../listing/listing";
+import type { RedditObject } from "../types";
+import type { WikiPageRevisionData } from "./types";
+
+import { Listing, Pager } from "../listing/listing";
+
+/** @internal */
+type WikiRevisionsRedditResponse = {
+  author: RedditObject<{ name: string }>;
+  timestamp: number;
+  page: string;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  revision_hidden: boolean;
+  reason: string;
+  id: string;
+};
+
+/** @internal */
+class WikiRevisionsPager extends Pager<WikiPageRevisionData> {
+  async fetch(context: ListingContext): Promise<WikiRevisionsListing> {
+    const pg = await this.nextPage<WikiRevisionsRedditResponse>(context);
+    return new WikiRevisionsListing(pg, context);
+  }
+}
+
+/** Listing class for wiki page revisions */
+export class WikiRevisionsListing extends Listing<WikiPageRevisionData> {
+  /** @internal */
+  constructor(
+    l: RedditListing<WikiRevisionsRedditResponse>,
+    context: ListingContext
+  ) {
+    let fetcher: Fetcher<WikiPageRevisionData> | undefined;
+    if (l.after != undefined) fetcher = new WikiRevisionsPager(l.after);
+
+    const items: WikiPageRevisionData[] = [];
+    for (const c of l.children) {
+      items.push({
+        author: c.author.data.name,
+        timestamp: c.timestamp,
+        page: c.page,
+        hidden: c.revision_hidden,
+        reason: c.reason,
+        revisionID: c.id,
+      });
+    }
+    super(context, items, fetcher);
+  }
+}

--- a/src/reddit/wiki/object.ts
+++ b/src/reddit/wiki/object.ts
@@ -1,0 +1,149 @@
+import type { WikiControls } from "./controls";
+import type { WikiPageData, WikiSettings } from "./types";
+
+/**
+ * Class for manipulating a wiki page
+ */
+export class WikiPage implements WikiPageData {
+  /** Subreddit display name */
+  subreddit: string;
+
+  /** Wiki page name */
+  page: string;
+
+  /** Markdown formatted wiki page contents */
+  contentMD: string;
+
+  /** UNDOCUMENTED */
+  mayRevise: boolean;
+
+  /** Reason for most recent revision */
+  reason: string | null;
+
+  /** Time of current revision creation in seconds */
+  revisionDate: number;
+
+  /** Username of person to make current revision */
+  revisionBy: string;
+
+  /** UUID of revision */
+  revisionID: string;
+
+  /** HTML formatted wiki page contents */
+  contentHTML: string;
+
+  /** @internal */
+  protected controls: WikiControls;
+
+  /** @internal */
+  constructor(controls: WikiControls, data: WikiPageData) {
+    this.controls = controls;
+
+    this.subreddit = data.subreddit;
+    this.page = data.page;
+    this.contentMD = data.contentMD;
+    this.mayRevise = data.mayRevise;
+    this.reason = data.reason;
+    this.revisionDate = data.revisionDate;
+    this.revisionBy = data.revisionBy;
+    this.revisionID = data.revisionID;
+    this.contentHTML = data.contentHTML;
+  }
+
+  /**
+   * Add a user as an editor on the wiki page
+   *
+   * @param username The name of an existing user to add as an editor
+   * @returns Does not return anything
+   */
+  async addEditor(username: string) {
+    return this.controls.addEditor(this.subreddit, this.page, username);
+  }
+
+  /**
+   * Remove a user as an editor on the wiki page
+   *
+   * @param username The name of an existing user to remove as an editor
+   * @returns Does not return anything
+   */
+  async removeEditor(username: string) {
+    return this.controls.removeEditor(this.subreddit, this.page, username);
+  }
+
+  /**
+   * Edit the contents of the wiki page along with a provided reason
+   *
+   * @param content The new content of the page in markdown format
+   * @param reason A string up to 256 characters long, consisting of printable characters
+   * @returns An empty object
+   */
+  async editPage(content: string, reason: string) {
+    return this.controls.editPage(
+      this.subreddit,
+      this.page,
+      content,
+      this.revisionID,
+      reason
+    );
+  }
+
+  /**
+   * Toggle the public visibility of the wiki page
+   *
+   * @returns Returns boolean indicating whether the page is now hidden (`true` indicates it is hidden)
+   */
+  async toggleVisibility() {
+    return this.controls.toggleVisibility(
+      this.subreddit,
+      this.page,
+      this.revisionID
+    );
+  }
+
+  /**
+   * Revert a wiki page to a previous revision
+   *
+   * @param revision The revision ID to which the page should be reverted
+   * @returns UNDOCUMENTED
+   */
+  async revertPage(revision: string) {
+    return this.controls.revertPage(this.subreddit, this.page, revision);
+  }
+
+  /**
+   * Generate a listing instance of discussions about the wiki page
+   * @returns UNIMPLEMENTED
+   */
+  getDiscussions() {
+    return this.controls.getDiscussions();
+  }
+
+  /**
+   * Generate a listing instance of recent changes for the wiki page
+   *
+   * @returns Listing of recent changes made to the wiki page
+   */
+  getRecentChanges() {
+    return this.controls.getRecentChangesForPage(this.subreddit, this.page);
+  }
+
+  /**
+   * Get the settings for the wiki page
+   *
+   * @returns An object containing the permission level of the page, whether it is hidden,
+   * and an array of editor usernames
+   */
+  async getSettings() {
+    return this.controls.getSettings(this.subreddit, this.page);
+  }
+
+  /**
+   *
+   * @param settings An object with the updated wiki page settings. All member fields must be set
+   * @returns An object containing the permission level of the page, whether it is hidden,
+   * and an array of editor usernames
+   */
+  async changeSettings(settings: WikiSettings) {
+    return this.controls.changeSettings(this.subreddit, this.page, settings);
+  }
+}

--- a/src/reddit/wiki/types.ts
+++ b/src/reddit/wiki/types.ts
@@ -1,0 +1,83 @@
+/**
+ * @enum
+ * Describes who can edit a wiki page
+ */
+export enum wikiPermissionLevel {
+  /** indicates that this subreddit's default wiki settings should get used */
+  default = 0,
+
+  /** indicates that only approved wiki contributors on this subreddit should be
+   * able to edit this page */
+  onlyApproved = 1,
+
+  /** indicates that only mods should be able to view and edit this page */
+  onlyModerators = 2,
+}
+
+/** Changeable settings for a wiki page */
+export interface WikiSettings {
+  /** Determines who should be allowed to access and edit a page */
+  permlevel: wikiPermissionLevel;
+
+  /** Determines whether this wiki page should appear on the public list of
+   * pages for this subreddit
+   */
+  listed: boolean;
+}
+
+/** Settings for a wiki page, including a readonly list of editors */
+export interface WikiSettingsAndEditors extends WikiSettings {
+  /** Array of usernames of wiki page editors */
+  editors: Array<string>;
+}
+
+/** The attributes specific to the WikiPage object */
+export interface WikiPageData {
+  /** Subreddit display name */
+  subreddit: string;
+
+  /** Wiki page name */
+  page: string;
+
+  /** Markdown formatted wiki page contents */
+  contentMD: string;
+
+  /** UNDOCUMENTED */
+  mayRevise: boolean;
+
+  /** Reason for most recent revision */
+  reason: string | null;
+
+  /** Time of current revision creation in seconds */
+  revisionDate: number;
+
+  /** Username of person to make current revision */
+  revisionBy: string;
+
+  /** UUID of revision */
+  revisionID: string;
+
+  /** HTML formatted wiki page contents */
+  contentHTML: string;
+}
+
+/** The attributes specific to wiki page revision objects */
+export interface WikiPageRevisionData {
+  /** Username of person to make current revision */
+  author: string;
+
+  /** Time of current revision creation in seconds */
+  timestamp: number;
+
+  /** Wiki page name */
+  page: string;
+
+  /** Is the page hidden from general view */
+  hidden: boolean;
+
+  /** Reason for revision */
+  reason: string | null;
+
+  /** UUID of revision */
+  revisionID: string;
+}


### PR DESCRIPTION
Currently working on the modmail implementation for snoots. This one was a touch trickier because of the quantity of new interfaces needed to make the whole thing work. Typedoc complained about nested interfaces, so the documentation now seems overwhelmingly polluted with new interfaces.

### Features

- New modmail controller that exposes the following
  - `modmail.getConversations( subreddit, after?, limit?, sort?, state? )`, to fetch an array of recent conversations. These are minimally detailed.
  - `modmail.getConversation( conversationID, markRead)`, to fetch a modmail conversation in detail. This makes use of an extended class to add these extra details
  - `modmail.approveParticipant( conversationID )`
  - `modmail.archiveConversation( conversationID )`
  - `modmail.disapproveParticipant( conversationID )`
  - `modmail.highlightConversation( conversationID )`
  - `modmail.muteParticipant( conversationID, duration )`
  - `modmail.tempBanParticipant( conversationID, duration)`
  - `modmail.unarchiveConversation( conversationID )`
  - `modmail.unbanParticipant( conversationID )`
  - `modmail.unmuteParticipant( conversationID )`
  - `modmail.getSubreddits( )`
- A `ModmailConversation` class to handle these new functions, along with data sent back by reddit
- A `ModmailConversationDetailed` class to handle conversations where extra details have been fetched, including messages, moderator actions, etc. This class extends `ModmailConversation`

### Not yet implemented
- `modmail.createNewConversation`. I just haven't got round to it yet
- `modmail.replyToConversation`. Similarly.
- `modmail.unhighlightConversation`. This requires the DELETE method on the gateway, which as yet is not implemented. It has been implemented in #83, and don't see a reason to re-implement it until a decision is made on the PR.
- `modmail.markAsRead`
- `modmail.markAsUnread`
- `modmail.getUnreadCount`

### Weird stuff
For the life of me, I can't seem to get the `api/mod/bulk_read` API endpoint to return anything other than Error 404. It remains implemented in `modmail.bulkMarkRead`, but as far as I can tell, this endpoint no longer exists.

Hope to get some feedback on this. Seems to be taking ages to get this pull requests looked at though.