### PR TITLE
feat: thumbnail implementation and documentation

### DIFF
--- a/src/reddit/post/object.ts
+++ b/src/reddit/post/object.ts
@@ -303,7 +303,7 @@ export class Post extends Lockable implements PostData {
   spoiler: boolean;
   subredditSubscribers: number;
   suggestedSort: Maybe<SuggestedSort>;
-  thumbnail: string;
+  thumbnail: "self" | "nsfw" | string;
   thumbnailHeight: Maybe<number>;
   thumbnailWidth: Maybe<number>;
   title: string;

--- a/src/reddit/post/object.ts
+++ b/src/reddit/post/object.ts
@@ -206,10 +206,25 @@ export interface PostData extends LockableData {
    */
   suggestedSort: Maybe<SuggestedSort>;
 
-  // TODO: Document or remove PostData.thumbnail*
-  // thumbnail: 'self' | string;
-  // thumbnailHeight?: number;
-  // thumbnailWidth?: number;
+  /**
+   * The redditmedia URL for the thumbnail of the post.
+   * Not to be confused with preview media, thumbnails are usually 140px wide.
+   * Self-posts and NSFW posts do not have thumbnails and return their
+   * respective type instead of an URL.
+   */
+  thumbnail: "self" | "nsfw" | string;
+
+  /**
+   * Height of the thumbnail image in pixels. `undefined` for self-posts and
+   * NSFW posts.
+   */
+  thumbnailHeight?: number;
+
+  /**
+   * Width of the thumbnail image in pixels. `undefined` for
+   * self-posts and NSFW posts.
+   */
+  thumbnailWidth?: number;
 
   /** The title of this post. */
   title: string;
@@ -288,9 +303,9 @@ export class Post extends Lockable implements PostData {
   spoiler: boolean;
   subredditSubscribers: number;
   suggestedSort: Maybe<SuggestedSort>;
-  // thumbnail: string;
-  // thumbnailHeight?: number;
-  // thumbnailWidth?: number;
+  thumbnail: string;
+  thumbnailHeight: Maybe<number>;
+  thumbnailWidth: Maybe<number>;
   title: string;
   upvoteRatio: number;
   url: string;
@@ -348,9 +363,9 @@ export class Post extends Lockable implements PostData {
     this.spoiler = data.spoiler;
     this.subredditSubscribers = data.subredditSubscribers;
     this.suggestedSort = data.suggestedSort;
-    // this.thumbnail = data.thumbnail;
-    // this.thumbnailHeight = data.thumbnailHeight;
-    // this.thumbnailWidth = data.thumbnailWidth;
+    this.thumbnail = data.thumbnail;
+    this.thumbnailHeight = data.thumbnailHeight;
+    this.thumbnailWidth = data.thumbnailWidth;
     this.title = data.title;
     this.upvoteRatio = data.upvoteRatio;
     this.url = data.url;


### PR DESCRIPTION
I tried to reimplement the thumbnail.

Other than uncommenting lines I added documentation and `nsfw` as a possible type.

I tried looking around but couldn't figure out how far you would like to abstract:

I would prefer if nsfw and self posts returned `undefined` instead of a `nsfw` or `self` as a string. So you'd have a src url or undefined. How are the nsfw and self string going to be helpful? No one is going to use thumbnail for type checking, there are better ways to do that. But that's just my opinion, maybe I'm missing something.

Another thought I had was using a type like
```
type Thumbnail = {
    url: string;
    height: number;
    width: number;
}
``` 
which would be optional. But I didn't find a precedence for something like that in your code.