### PR TITLE
fix: sh compatibility

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,9 +4,8 @@
 set -e
 echo "Linting commits before push..."
 while IFS= read -r line; do
-  parts=($line)
-  old="${parts[3]}"
-  new="${parts[1]}"
+  old=$(echo "$line" | awk '{print $4}')
+  new=$(echo "$line" | awk '{print $2}')
 
   if [ "${old}" = "0000000000000000000000000000000000000000" ]; then
     npx commitlint -f 'master' -t "$new"


### PR DESCRIPTION
this is a weird one. Husky wouldn't let me push. 

```
Linting commits before push...
.husky/pre-push: 7: Syntax error: "(" unexpected (expecting "done")
husky - pre-push hook exited with code 2 (error)
```

I did a little digging and found out that the array on line 7 isn't SH-shell compatible. 

With that being said, it returned the same error when I ran it with bash and fish.

This might very well be a me-problem, I have no idea. Anyways, I rewrote the line to use awk. I don't insist on the PR, I just want to share my fix. Thank you and have a nice weekend.